### PR TITLE
Builds glt22 release apk, signs it and uploads to latest release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
       - name: Build
-        run: ./gradlew assemble
+        run: ./gradlew assembleGlt22Release
 
       - name: Assemble Release Bundle
         run: |
@@ -28,6 +28,17 @@ jobs:
         id: sign_app
         with:
           releaseDirectory: app/build/outputs/bundle/glt22Release
+          signingKeyBase64: ${{ secrets.KEYSTORE }}
+          alias: ${{ secrets.KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+
+      - name: Sign APK
+        uses: r0adkll/sign-android-release@v1
+        # ID used to access action output
+        id: sign_apk
+        with:
+          releaseDirectory: app/build/outputs/apk/glt22/release
           signingKeyBase64: ${{ secrets.KEYSTORE }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
@@ -51,3 +62,10 @@ jobs:
           releaseFiles: ${{steps.sign_app.outputs.signedReleaseFile}}
           track: production
 
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: ${{steps.sign_apk.outputs.signedReleaseFile}}
+          asset_name: GLT_app.apk
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
# Acknowledgments
Please check the following boxes with an `x` if they apply:
* [ ] I have read the recent version of the [contribution guide](
  https://github.com/linuxtage/EventFahrplan/blob/master/CONTRIBUTING.md) before creating this pull request.
* [ ] I have checked a few other pull requests to see how they are written.
* [ ] The feature I want to propose would be useful for the majority of users, not only for me personally.
* [ ] I am aware that EventFahrplan is mostly developed by one person in their unpaid spare time.
* [ ] I can help myself to get this feature implemented or know someone who wants to do it.

# Description
<!--
- Short summary of what you are trying to accomplish.
- Link to the associated issue if applicable.
- Link to an external bug tracker if applicable.
- Which device/emulator and Android version did you test on?
-->

# Before
<!--
- Describe the behavior before the change.
- Add screenshot(s).
-->

# After
<!--
- Describe the behavior after the change.
- Add screenshot(s).
-->

<!-- Remove it this pull request does not resolve an issue -->
Resolves #
